### PR TITLE
Add APNs configuration for iOS push notifications

### DIFF
--- a/src/main/java/com/bonju/review/notification/service/FcmService.java
+++ b/src/main/java/com/bonju/review/notification/service/FcmService.java
@@ -24,12 +24,19 @@ public class FcmService {
             .putHeader("Urgency", "high")
             .build();
 
+    ApnsConfig apnsConfig = ApnsConfig.builder()
+            .setAps(Aps.builder()
+                    .setAlert(ApsAlert.builder().setTitle(title).setBody(body).build())
+                    .build())
+            .build();
+
     Message msg = Message.builder()
             .setToken(token)
             // 기존 알림도 유지 (Android/Chrome 호환)
             .setNotification(Notification.builder().setTitle(title).setBody(body).build())
             // iOS PWA 안정화용 webpush 블록 추가
             .setWebpushConfig(webpush)
+            .setApnsConfig(apnsConfig)
             .build();
 
     try {


### PR DESCRIPTION
## Summary
- build APNs configuration with alert title and body in `FcmService`
- attach APNs config to FCM message so iOS devices receive notifications

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4037aec848325953f171e9abd8fc4