### PR TITLE
Add test profile retrieval API

### DIFF
--- a/src/main/java/com/bonju/review/dev/config/TestProfileClockConfiguration.java
+++ b/src/main/java/com/bonju/review/dev/config/TestProfileClockConfiguration.java
@@ -1,0 +1,19 @@
+package com.bonju.review.dev.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("test")
+public class TestProfileClockConfiguration {
+
+  private static final String DEFAULT_ZONE_ID = "Asia/Seoul";
+
+  @Bean
+  public Clock clock() {
+    return Clock.system(ZoneId.of(DEFAULT_ZONE_ID));
+  }
+}

--- a/src/main/java/com/bonju/review/dev/controller/TestProfileController.java
+++ b/src/main/java/com/bonju/review/dev/controller/TestProfileController.java
@@ -1,6 +1,7 @@
 package com.bonju.review.dev.controller;
 
 import com.bonju.review.dev.dto.TestProfileResponse;
+import com.bonju.review.dev.service.TestProfileResponseProvider;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,15 +12,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/test/profile")
 public class TestProfileController {
 
-  private static final TestProfileResponse TEST_PROFILE_RESPONSE = new TestProfileResponse(
-      "test-user-id",
-      "테스트 사용자",
-      "test-user@example.com",
-      "https://example.com/test-user.png"
-  );
+  private final TestProfileResponseProvider testProfileResponseProvider;
+
+  public TestProfileController(TestProfileResponseProvider testProfileResponseProvider) {
+    this.testProfileResponseProvider = testProfileResponseProvider;
+  }
 
   @GetMapping
   public TestProfileResponse getTestProfile() {
-    return TEST_PROFILE_RESPONSE;
+    return testProfileResponseProvider.provide();
   }
 }

--- a/src/main/java/com/bonju/review/dev/controller/TestProfileController.java
+++ b/src/main/java/com/bonju/review/dev/controller/TestProfileController.java
@@ -1,0 +1,25 @@
+package com.bonju.review.dev.controller;
+
+import com.bonju.review.dev.dto.TestProfileResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("test")
+@RestController
+@RequestMapping("/api/test/profile")
+public class TestProfileController {
+
+  private static final TestProfileResponse TEST_PROFILE_RESPONSE = new TestProfileResponse(
+      "test-user-id",
+      "테스트 사용자",
+      "test-user@example.com",
+      "https://example.com/test-user.png"
+  );
+
+  @GetMapping
+  public TestProfileResponse getTestProfile() {
+    return TEST_PROFILE_RESPONSE;
+  }
+}

--- a/src/main/java/com/bonju/review/dev/domain/TestProfileUser.java
+++ b/src/main/java/com/bonju/review/dev/domain/TestProfileUser.java
@@ -1,0 +1,17 @@
+package com.bonju.review.dev.domain;
+
+import com.bonju.review.dev.dto.TestProfileResponse;
+import java.time.LocalDateTime;
+
+public record TestProfileUser(
+    String id,
+    String nickname,
+    String email,
+    String profileImageUrl,
+    String status
+) {
+
+  public TestProfileResponse toResponse(LocalDateTime createdAt) {
+    return new TestProfileResponse(id, nickname, email, profileImageUrl, status, createdAt);
+  }
+}

--- a/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
+++ b/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
@@ -1,9 +1,12 @@
 package com.bonju.review.dev.dto;
 
+import java.time.LocalDateTime;
+
 public record TestProfileResponse(
     String id,
     String nickname,
     String email,
-    String profileImageUrl
+    String profileImageUrl,
+    LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
+++ b/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
@@ -7,6 +7,7 @@ public record TestProfileResponse(
     String nickname,
     String email,
     String profileImageUrl,
+    String status,
     LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
+++ b/src/main/java/com/bonju/review/dev/dto/TestProfileResponse.java
@@ -1,0 +1,9 @@
+package com.bonju.review.dev.dto;
+
+public record TestProfileResponse(
+    String id,
+    String nickname,
+    String email,
+    String profileImageUrl
+) {
+}

--- a/src/main/java/com/bonju/review/dev/service/TestProfileResponseProvider.java
+++ b/src/main/java/com/bonju/review/dev/service/TestProfileResponseProvider.java
@@ -1,0 +1,34 @@
+package com.bonju.review.dev.service;
+
+import com.bonju.review.dev.dto.TestProfileResponse;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("test")
+public class TestProfileResponseProvider {
+
+  private static final String TEST_USER_ID = "test-user-id";
+  private static final String TEST_USER_NICKNAME = "테스트 사용자";
+  private static final String TEST_USER_EMAIL = "test-user@example.com";
+  private static final String TEST_USER_PROFILE_IMAGE_URL = "https://example.com/test-user.png";
+
+  private final Clock clock;
+
+  public TestProfileResponseProvider(Clock clock) {
+    this.clock = clock;
+  }
+
+  public TestProfileResponse provide() {
+    var createdAt = LocalDateTime.now(clock);
+    return new TestProfileResponse(
+        TEST_USER_ID,
+        TEST_USER_NICKNAME,
+        TEST_USER_EMAIL,
+        TEST_USER_PROFILE_IMAGE_URL,
+        createdAt
+    );
+  }
+}

--- a/src/main/java/com/bonju/review/dev/service/TestProfileResponseProvider.java
+++ b/src/main/java/com/bonju/review/dev/service/TestProfileResponseProvider.java
@@ -1,5 +1,6 @@
 package com.bonju.review.dev.service;
 
+import com.bonju.review.dev.domain.TestProfileUser;
 import com.bonju.review.dev.dto.TestProfileResponse;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -10,10 +11,13 @@ import org.springframework.stereotype.Service;
 @Profile("test")
 public class TestProfileResponseProvider {
 
-  private static final String TEST_USER_ID = "test-user-id";
-  private static final String TEST_USER_NICKNAME = "테스트 사용자";
-  private static final String TEST_USER_EMAIL = "test-user@example.com";
-  private static final String TEST_USER_PROFILE_IMAGE_URL = "https://example.com/test-user.png";
+  private static final TestProfileUser TEST_PROFILE_USER = new TestProfileUser(
+      "test-user-id",
+      "테스트 사용자",
+      "test-user@example.com",
+      "https://example.com/test-user.png",
+      "ACTIVE"
+  );
 
   private final Clock clock;
 
@@ -23,12 +27,6 @@ public class TestProfileResponseProvider {
 
   public TestProfileResponse provide() {
     var createdAt = LocalDateTime.now(clock);
-    return new TestProfileResponse(
-        TEST_USER_ID,
-        TEST_USER_NICKNAME,
-        TEST_USER_EMAIL,
-        TEST_USER_PROFILE_IMAGE_URL,
-        createdAt
-    );
+    return TEST_PROFILE_USER.toResponse(createdAt);
   }
 }

--- a/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
+++ b/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
@@ -1,14 +1,19 @@
 package com.bonju.review.dev.controller;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,10 +25,18 @@ class TestProfileControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  @MockBean
+  private Clock clock;
+
   @Test
   @DisplayName("테스트 프로필 조회 API는 고정된 사용자 정보를 반환한다.")
   void getTestProfileReturnsFixedUserInformation() throws Exception {
     // Given
+    var zoneId = ZoneId.of("Asia/Seoul");
+    var expectedCreatedAt = LocalDateTime.of(2024, 1, 1, 9, 0, 0);
+    var fixedInstant = expectedCreatedAt.atZone(zoneId).toInstant();
+    when(clock.instant()).thenReturn(fixedInstant);
+    when(clock.getZone()).thenReturn(zoneId);
 
     // When
     var resultActions = mockMvc.perform(get("/api/test/profile"));
@@ -35,6 +48,7 @@ class TestProfileControllerTest {
         .andExpect(jsonPath("$.id").value("test-user-id"))
         .andExpect(jsonPath("$.nickname").value("테스트 사용자"))
         .andExpect(jsonPath("$.email").value("test-user@example.com"))
-        .andExpect(jsonPath("$.profileImageUrl").value("https://example.com/test-user.png"));
+        .andExpect(jsonPath("$.profileImageUrl").value("https://example.com/test-user.png"))
+        .andExpect(jsonPath("$.createdAt").value("2024-01-01T09:00:00"));
   }
 }

--- a/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
+++ b/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
@@ -6,14 +6,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.bonju.review.dev.service.TestProfileResponseProvider;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +32,15 @@ class TestProfileControllerTest {
 
   @MockBean
   private Clock clock;
+
+  @TestConfiguration
+  static class ControllerTestConfiguration {
+
+    @Bean
+    TestProfileResponseProvider testProfileResponseProvider(Clock clock) {
+      return new TestProfileResponseProvider(clock);
+    }
+  }
 
   @Test
   @DisplayName("테스트 프로필 조회 API는 고정된 사용자 정보를 반환한다.")
@@ -42,13 +56,23 @@ class TestProfileControllerTest {
     var resultActions = mockMvc.perform(get("/api/test/profile"));
 
     // Then
-    resultActions
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value("test-user-id"))
-        .andExpect(jsonPath("$.nickname").value("테스트 사용자"))
-        .andExpect(jsonPath("$.email").value("test-user@example.com"))
-        .andExpect(jsonPath("$.profileImageUrl").value("https://example.com/test-user.png"))
-        .andExpect(jsonPath("$.createdAt").value("2024-01-01T09:00:00"));
+    resultActions.andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+    var expectedResponseFields = createExpectedResponseFields();
+    for (var entry : expectedResponseFields.entrySet()) {
+      resultActions.andExpect(jsonPath(entry.getKey()).value(entry.getValue()));
+    }
+  }
+
+  private Map<String, String> createExpectedResponseFields() {
+    var expectedResponseFields = new LinkedHashMap<String, String>();
+    expectedResponseFields.put("$.id", "test-user-id");
+    expectedResponseFields.put("$.nickname", "테스트 사용자");
+    expectedResponseFields.put("$.email", "test-user@example.com");
+    expectedResponseFields.put("$.profileImageUrl", "https://example.com/test-user.png");
+    expectedResponseFields.put("$.status", "ACTIVE");
+    expectedResponseFields.put("$.createdAt", "2024-01-01T09:00:00");
+    return expectedResponseFields;
   }
 }

--- a/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
+++ b/src/test/java/com/bonju/review/dev/controller/TestProfileControllerTest.java
@@ -1,0 +1,40 @@
+package com.bonju.review.dev.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TestProfileController.class)
+@ActiveProfiles("test")
+class TestProfileControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("테스트 프로필 조회 API는 고정된 사용자 정보를 반환한다.")
+  void getTestProfileReturnsFixedUserInformation() throws Exception {
+    // Given
+
+    // When
+    var resultActions = mockMvc.perform(get("/api/test/profile"));
+
+    // Then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value("test-user-id"))
+        .andExpect(jsonPath("$.nickname").value("테스트 사용자"))
+        .andExpect(jsonPath("$.email").value("test-user@example.com"))
+        .andExpect(jsonPath("$.profileImageUrl").value("https://example.com/test-user.png"));
+  }
+}


### PR DESCRIPTION
## Summary
- add a `/api/test/profile` endpoint restricted to the `test` profile that serves a deterministic user payload
- define a dedicated `TestProfileResponse` record to express the response body
- cover the controller with a Spring MVC slice test validating the returned JSON structure

## Testing
- ./gradlew test --tests com.bonju.review.dev.controller.TestProfileControllerTest *(fails: dependency downloads blocked by 403 responses from Maven Central and Spring repositories)*

------
https://chatgpt.com/codex/tasks/task_e_69004aabc0508325b6532c0d6516cc4e