### PR TITLE
Align knowledge responses with text field

### DIFF
--- a/src/main/java/com/bonju/review/knowledge/dto/DayKnowledgeResponseDto.java
+++ b/src/main/java/com/bonju/review/knowledge/dto/DayKnowledgeResponseDto.java
@@ -9,13 +9,13 @@ public class DayKnowledgeResponseDto {
     private final int dayType; // "0일차", "3일차", "7일차", "30일차"
     private final Long id;
     private final String title;
-    private final String content;
+    private final String text;
 
     @Builder
-    private DayKnowledgeResponseDto(int dayType, Long id, String title, String content) {
+    private DayKnowledgeResponseDto(int dayType, Long id, String title, String text) {
         this.dayType = dayType;
         this.id = id;
         this.title = title;
-        this.content = content;
+        this.text = text;
     }
 }

--- a/src/main/java/com/bonju/review/knowledge/dto/KnowledgeDetailResponseDto.java
+++ b/src/main/java/com/bonju/review/knowledge/dto/KnowledgeDetailResponseDto.java
@@ -10,6 +10,6 @@ import java.time.LocalDateTime;
 public class KnowledgeDetailResponseDto {
   private Long id;
   private String title;
-  private String content;
+  private String text;
   private LocalDateTime createdAt;
 }

--- a/src/main/java/com/bonju/review/knowledge/service/KnowledgeReadServiceImpl.java
+++ b/src/main/java/com/bonju/review/knowledge/service/KnowledgeReadServiceImpl.java
@@ -31,7 +31,7 @@ public class KnowledgeReadServiceImpl implements KnowledgeReadService{
       return KnowledgeDetailResponseDto.builder()
               .id(knowledge.getId())
               .title(knowledge.getTitle())
-              .content(knowledge.getText())
+              .text(knowledge.getText())
               .createdAt(knowledge.getCreatedAt())
               .build();
 

--- a/src/main/java/com/bonju/review/knowledge/service/knowledge_list/TodayKnowledgeListServiceImpl.java
+++ b/src/main/java/com/bonju/review/knowledge/service/knowledge_list/TodayKnowledgeListServiceImpl.java
@@ -53,7 +53,7 @@ public class TodayKnowledgeListServiceImpl implements TodayKnowledgeListService 
                             .dayType(dayType.getDaysAgo())
                             .id(knowledge.getId())
                             .title(knowledge.getTitle())
-                            .content(markdownConverter.convertTruncatedParagraph(knowledge.getText()))
+                            .text(markdownConverter.convertTruncatedParagraph(knowledge.getText()))
                             .build())
                     .toList();
         } catch (DataAccessException e) {

--- a/src/test/java/com/bonju/review/knowledge/Integration/KnowledgeDetailIntegrationTest.java
+++ b/src/test/java/com/bonju/review/knowledge/Integration/KnowledgeDetailIntegrationTest.java
@@ -32,7 +32,7 @@ class KnowledgeDetailIntegrationTest {
   public static final String KAKAO_ID = "123";
   public static final LocalDateTime FIXED_DATE = LocalDateTime.of(2025, 5, 10, 0, 0);
   public static final String KNOWLEDGE_TITLE = "지식 제목";
-  public static final String KNOWLEDGE_CONTENT = "지식 내용";
+  public static final String KNOWLEDGE_TEXT = "지식 내용";
   public static final String PATH = "/knowledge/1";
   public static final String NON_EXISTING_KNOWLEDGE_PATH = "/knowledge/999";
   @Autowired
@@ -66,7 +66,7 @@ class KnowledgeDetailIntegrationTest {
     assertThat(actual.getId()).isEqualTo(savedKnowledge.getId());
     assertThat(actual.getCreatedAt()).isEqualTo(FIXED_DATE);
     assertThat(actual.getTitle()).isEqualTo(KNOWLEDGE_TITLE);
-    assertThat(actual.getContent()).isEqualTo(KNOWLEDGE_CONTENT);
+    assertThat(actual.getText()).isEqualTo(KNOWLEDGE_TEXT);
   }
 
   @DisplayName("존재하지 않는 지식 ID로 요청하면 404를 반환한다")
@@ -131,7 +131,7 @@ class KnowledgeDetailIntegrationTest {
     return Knowledge.builder()
             .user(user)
             .title(KNOWLEDGE_TITLE)
-            .text(KNOWLEDGE_CONTENT)
+            .text(KNOWLEDGE_TEXT)
             .createdAt(FIXED_DATE)
             .build();
   }

--- a/src/test/java/com/bonju/review/knowledge/controller/KnowledgeDetailControllerTest.java
+++ b/src/test/java/com/bonju/review/knowledge/controller/KnowledgeDetailControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class KnowledgeDetailControllerTest {
   private static final LocalDateTime FIXED_TIME = LocalDateTime.of(2025, 5, 10, 0, 0,0);
   public static final String KNOWLEDGE_TITLE = "지식 제목";
-  public static final String KNOWLEDGE_CONTENT = "지식 내용";
+  public static final String KNOWLEDGE_TEXT = "지식 내용";
   public static final String PATH = "/knowledge/1";
   public static final String BAD_PATH = "/knowledge/0";
 
@@ -51,7 +51,7 @@ class KnowledgeDetailControllerTest {
     KnowledgeDetailResponseDto expected = KnowledgeDetailResponseDto.builder()
             .id(1L)
             .title(KNOWLEDGE_TITLE)
-            .content(KNOWLEDGE_CONTENT)
+            .text(KNOWLEDGE_TEXT)
             .createdAt(FIXED_TIME)
             .build();
 
@@ -69,7 +69,7 @@ class KnowledgeDetailControllerTest {
 
     assertThat(actual.getId()).isEqualTo(expected.getId());
     assertThat(actual.getTitle()).isEqualTo(expected.getTitle());
-    assertThat(actual.getContent()).isEqualTo(expected.getContent());
+    assertThat(actual.getText()).isEqualTo(expected.getText());
     assertThat(actual.getCreatedAt()).isEqualTo(expected.getCreatedAt());
   }
 

--- a/src/test/java/com/bonju/review/knowledge/service/KnowledgeServiceTest.java
+++ b/src/test/java/com/bonju/review/knowledge/service/KnowledgeServiceTest.java
@@ -29,7 +29,7 @@ class KnowledgeServiceTest {
 
   private static final LocalDateTime FIXED_DATE = LocalDateTime.of(2025, 5, 9, 0, 0);
   private static final String TITLE = "제목";
-  private static final String CONTENT = "내용";
+  private static final String TEXT = "내용";
 
   @InjectMocks
   KnowledgeReadServiceImpl knowledgeReadService;
@@ -59,7 +59,7 @@ class KnowledgeServiceTest {
     verify(knowledgeReadRepository).findKnowledge(user, id);
     assertThat(response.getId()).isEqualTo(id);
     assertThat(response.getTitle()).isEqualTo(TITLE);
-    assertThat(response.getContent()).isEqualTo(CONTENT);
+    assertThat(response.getText()).isEqualTo(TEXT);
     assertThat(response.getCreatedAt()).isEqualTo(FIXED_DATE);
   }
 
@@ -164,7 +164,7 @@ class KnowledgeServiceTest {
     Knowledge knowledge = Knowledge.builder()
             .user(user)
             .title(TITLE)
-            .text(CONTENT)
+            .text(TEXT)
             .createdAt(FIXED_DATE)
             .build();
     ReflectionTestUtils.setField(knowledge, "id", id);


### PR DESCRIPTION
## Summary
- rename knowledge response DTO fields from `content` to `text` to align with the entity
- update knowledge read and list services to populate the new `text` field in responses
- adjust knowledge-related unit and integration tests to assert against the `text` field

## Testing
- ./gradlew test *(fails: dependency downloads blocked with 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_69074c7b7ce883258fd72dedb4bf3919